### PR TITLE
Replace the topic get_battery_state with a service

### DIFF
--- a/qrb_robot_base_manager/include/qrb_robot_base_manager/charger_manager.hpp
+++ b/qrb_robot_base_manager/include/qrb_robot_base_manager/charger_manager.hpp
@@ -16,6 +16,7 @@ namespace qrb
 {
 namespace robot_base_manager
 {
+
 enum class ChargerState
 {
   unknown,
@@ -59,7 +60,7 @@ public:
   bool get_current();
   bool get_pile_state();
   bool get_charger_state();
-  bool get_power_state();
+  PowerState get_power_state();
 
   void register_error_callback(std::function<void(const Error &)>);
   void register_pile_state_callback(std::function<void(const uint32_t)> cb);
@@ -71,8 +72,11 @@ private:
   std::condition_variable msg_cond_;
   bool start_charging_ack_ = false;
   bool stop_charging_ack_ = false;
-
+  bool is_updating_ = false;
   PowerState current_state_{};
+  bool get_voltage_ack_ = false;
+  bool get_current_ack_ = false;
+  bool get_state_machine_ack_ = false;
 
   std::function<void(const PowerState &)> power_state_cb_{ nullptr };
   std::function<void(const Error &)> error_cb_{ nullptr };

--- a/qrb_robot_base_manager/src/client_manager.cpp
+++ b/qrb_robot_base_manager/src/client_manager.cpp
@@ -44,13 +44,13 @@ void ClientManager::qrc_message_handle(void * data)
       get_instance().set_client_ack_ = true;
       get_instance().client_ = static_cast<Client>(message->client);
       std::cout << "ClientManager: set client result" << ", client: " << message->client
-            << std::endl;
+                << std::endl;
       break;
     case client_msg_type_e::GET_CLIENT:
       get_instance().get_client_ack_ = true;
       get_instance().client_ = static_cast<Client>(message->client);
       std::cout << "ClientManager: get client result" << ", client: " << message->client
-            << std::endl;
+                << std::endl;
       break;
     default:
       std::cerr << "ClientManager: qrc message not valid, type: " << message->msg_type << std::endl;

--- a/qrb_ros_robot_base/include/qrb_ros_robot_base/robot_base/charger_controller.hpp
+++ b/qrb_ros_robot_base/include/qrb_ros_robot_base/robot_base/charger_controller.hpp
@@ -27,8 +27,11 @@ private:
 
   rclcpp::Publisher<sensor_msgs::msg::BatteryState>::SharedPtr battery_pub_;
   rclcpp::Subscription<qrb_ros_robot_base_msgs::msg::ChargerCmd>::SharedPtr charge_cmd_sub_;
-  rclcpp::Service<qrb_ros_robot_base_msgs::srv::GetBatteryState>::SharedPtr get_battery_state_server_;
+  rclcpp::Service<qrb_ros_robot_base_msgs::srv::GetBatteryState>::SharedPtr
+      get_battery_state_server_;
 
+  sensor_msgs::msg::BatteryState power_state_to_msg(
+      const qrb::robot_base_manager::PowerState & state);
   void publish_battery(const qrb::robot_base_manager::PowerState & state);
   void get_battery_state_callback(const std::shared_ptr<rmw_request_id_t> request_header,
       const std::shared_ptr<qrb_ros_robot_base_msgs::srv::GetBatteryState::Request> request,


### PR DESCRIPTION
  When requesting battery status using get_battery_state topic, the
  status is published via the /battery topic. This notice other
  subscribers, who did not request the battery status, which is
  an unreasonable design.

  We want only the requester to receive the updated battery status.
  Therefore, changing get_battery_state from a topic to a service.