### PR TITLE
fix: replace pull_request_target with pull_request in workflows

### DIFF
--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -1,6 +1,6 @@
 name: Qualcomm Preflight Checks
 on:
-  pull_request_target:
+  pull_request:
     branches: [ main ]
   push:
     branches: [ main ]


### PR DESCRIPTION
Replace `pull_request_target:` with `pull_request:` in GitHub Actions workflow files.

**Reason:** `pull_request_target` runs with write permissions and access to secrets, even for PRs from forks. This poses a security risk (IT requirement to remediate). `pull_request` runs in the context of the fork with read-only permissions, which is the safe default for most CI checks.
