### PR TITLE
docs: remove RB3 Gen2 references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <div align="center">
   <h1>qrb_ros_robot_base</h1>
   <p align="center">
-   <img src="https://s7d1.scene7.com/is/image/dmqualcommprod/rb3gen2-dev-kits-hero-7" alt="Qualcomm QRB ROS" title="Qualcomm QRB ROS" />
   </p>
   <p>ROS2 package for controlling AMR robot base</p>
   <a href="https://ubuntu.com/download/qualcomm-iot" target="_blank"><img src="https://img.shields.io/badge/Qualcomm%20Ubuntu-E95420?style=for-the-badge&logo=ubuntu&logoColor=white" alt="Qualcomm Ubuntu"></a>
@@ -180,8 +179,6 @@ It will init robot base, sync time with MCB, provide ROS interfaces for control 
     <th>Hardware Overview</th>
   </tr>
   <tr>
-    <td>Qualcomm Dragonwing™ RB3 Gen2</td>
-    <th><a href="https://www.qualcomm.com/developer/hardware/rb3-gen-2-development-kit"><img src="https://s7d1.scene7.com/is/image/dmqualcommprod/rb3-gen2-carousel?fmt=webp-alpha&qlt=85" width="180"/></a></th>
   </tr>
   <tr>
     <td>Qualcomm Dragonwing™ IQ-9075 EVK</td>


### PR DESCRIPTION
## Summary
- Remove RB3 Gen2 references from the README, since RB3 Gen2 is no longer a supported target.

## Details
Removes RB3 Gen2 references from the README (supported-hardware table entry, and any RB3-specific banner image), keeping IQ-9075 EVK as the reference hardware. Documentation-only change.